### PR TITLE
Properly escape backticks and newlines

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Runs a PR command writing title and description via GPT-4o
 """
@@ -73,8 +74,14 @@ def main():
     command = command.replace("```bash\n", "")
     command = command.replace("```", "")
 
-    # Remove the ` backticks since they cause issues with bash
-    command = command.replace("`", "")
+    # Escape backticks so they are literal in the shell instead of being interpreted as a command substitution
+    # ` -> \`
+    command = command.replace("`", "\\`")
+
+    # Convert literal "\n" strings to actual newlines if necessary
+    # In many cases, the model will return actual newline chars already,
+    # but if it returns literal backslash-n sequences, convert them:
+    command = command.replace("\\n", "\n")
 
     # Ensure it starts with `gh pr create`
     if not command.startswith("gh pr create"):


### PR DESCRIPTION
# Goals
- Fix issues with backtick handling in shell commands.
- Change backslash-n sequences to actual newlines.

# Key Changes
- Added a shebang line for running the script using Python 3.
- Modified backtick handling to escape them instead of removing.
- Converted literal newline sequences to actual newline characters if necessary.

# Tests
- Verified that escaping backticks does not affect other functionalities.
- Ensured new behavior is consistent across different command executions.